### PR TITLE
Support Functions

### DIFF
--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -162,8 +162,10 @@ export namespace ASON {
         }
       }
 
-      // @ts-ignore
-      if (value instanceof ArrayBufferView) {
+      if (isFunction(value)) {
+        return this.putDataSegment(value);
+        // @ts-ignore: ArrayBufferView is global
+      } else if (value instanceof ArrayBufferView) {
         return this.putArrayDataSegment(value);
       } else if (value instanceof Map) {
         return this.putMap(value);

--- a/packages/test/assembly/__tests__/index.spec.ts
+++ b/packages/test/assembly/__tests__/index.spec.ts
@@ -39,6 +39,7 @@ describe("ASON test suite", () => {
   test("really long static strings", testStaticStrings);
   test("typed array", testTypedArray);
   test("extension", objectExtension);
+  test("funtions", testCallbacks);
 
   describe("map", () => {
     test("int to int maps", () => { testMap<u8, u8>([1, 2, 3], [3, 6, 9]); });
@@ -402,4 +403,11 @@ function objectExtension(): void {
   let buffer = ASON.serialize(a);
   let b = ASON.deserialize<ExtendedVector>(buffer);
   expect(a).toStrictEqual(b);
+}
+
+function testCallbacks(): void {
+  let a = (): void => {};
+  let buffer = ASON.serialize(a);
+  let b = ASON.deserialize<() => void>(buffer);
+  b();
 }


### PR DESCRIPTION
Functions are only data. We can serialize them as a data copy, and everything works fine.

New caveats for Function serialization:

- No closure support (just like assemblyscript)
- Will require some magic to serialize closure context (and it will be copied, not moved)
- If the function table can change, then function serialization cannot be supported, unless we also somehow manage to serialize the table entry as well (this is currently not possible)

Normal users don't need to worry about these things.