### PR TITLE
Checking idof<T>() does not suffice for type checking

### DIFF
--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -228,7 +228,7 @@ export namespace ASON {
       let entry = customTable.allocate();
       let entryId = this.entryId++;
       entry.entryId = entryId;
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
       entry.offset = offsetof<U>();
       entry.byteLength = length;
       // @ts-ignore: method index access, safe
@@ -258,7 +258,7 @@ export namespace ASON {
 
       let mapEntry = this.mapReferenceTable.allocate();
       mapEntry.entryId = mapEntryId;
-      mapEntry.rtId = idof<U>();
+      mapEntry.rtId = getObjectType(changetype<usize>(value));
 
       // @ts-ignore: type U is guaranteed to be a Map
       let maxkv = max<i32>(sizeof<indexof<U>>(), sizeof<valueof<U>>());
@@ -349,7 +349,7 @@ export namespace ASON {
       let entryId = this.entryId++;
       let entry = this.setReferenceTable.allocate();
       entry.entryId = entryId;
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
       entry.entrySize = entrySize;
       entry.capacity = capacity;
 
@@ -391,7 +391,7 @@ export namespace ASON {
 
       entry.byteLength = size;
       entry.entryId = entryId;
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
 
       // write the data to the table after the header
       let segment = this.dataSegmentTable.allocateSegment(<i32>size);
@@ -420,7 +420,7 @@ export namespace ASON {
       // @ts-ignore: valueof<U> is defined
       entry.align = alignof<valueof<U>>();
       entry.entryId = entryId;
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
 
       // @ts-ignore: valueof<U> is defined
       let size = <usize>arrayLength << (alignof<valueof<U>>());
@@ -451,7 +451,7 @@ export namespace ASON {
       entry.entryId = entryId;
       let offset = getObjectSize(value);
       entry.offset = offset;
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
       let segment = this.referenceTable.allocateSegment(<i32>offset);
       this.segments.set(entryId, segment);
       return entryId;
@@ -467,7 +467,7 @@ export namespace ASON {
       } else {
         entry.length = value.length;
       }
-      entry.rtId = idof<U>();
+      entry.rtId = getObjectType(changetype<usize>(value));
       return entryId;
     }
 

--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -31,7 +31,7 @@ import {
   SetReferenceEntry,
   StaticReferenceEntry,
   Table,
- } from "./util";
+} from "./util";
 
 class Dummy {}
 
@@ -850,8 +850,12 @@ export namespace ASON {
       // all the references have been allocated, let's get entry 0 and validate type info
       let entry0 = changetype<usize>(entryMap.get(0));
       if (isReference<T>()) {
-        assert(getObjectType(entry0) == idof<T>() || __instanceof(entry0, idof<T>()));
+        // in the case of functions, idof<T>() returns 0, and breaks everything
+        if (!isFunction<T>()) {
+          assert(getObjectType(entry0) == idof<T>() || __instanceof(entry0, idof<T>()));
+        }
       } else {
+        // the type is a number, and we can validate the rtid of a Box<T>
         assert(getObjectType(entry0) == idof<Box<T>>());
       }
 

--- a/packages/assembly/package-lock.json
+++ b/packages/assembly/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@ason/assembly",
-			"version": "0.1.3",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"assemblyscript": "^0.19.22"

--- a/packages/test/package-lock.json
+++ b/packages/test/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@ason/test",
-			"version": "0.1.3",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@as-pect/cli": "^6.2.4",

--- a/packages/transform/package-lock.json
+++ b/packages/transform/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@ason/transform",
-			"version": "0.1.3",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"visitor-as": "^0.8.0"


### PR DESCRIPTION
This bug is generated when we attempt to serialize something as a base class. The fix is to inspect the rtid of the reference at runtime instead of using the compile time constant provided by the compiler which can be wrong.