### PR TITLE
test and validate custom serializable references can be nullable

### DIFF
--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -158,7 +158,11 @@ export namespace ASON {
             ERROR("Custom ASON serializtion can only be performed on a reference.");
           }
 
-          return this.putCustom(value);
+          if (isNullable(value)) {
+            return this.putCustom(value!);
+          } else {
+            return this.putCustom(value);
+          }
         }
       }
 

--- a/packages/test/assembly/__tests__/index.spec.ts
+++ b/packages/test/assembly/__tests__/index.spec.ts
@@ -77,6 +77,8 @@ describe("ASON test suite", () => {
     test("virtual deserialization", testVirtual);
   });
   test("Major objects that should engage all parts of ASON", testHugeObject);
+
+  test("nullable custom", testNullableCustom);
 });
 
 function testBasicVectors(): void {
@@ -426,4 +428,16 @@ function testVirtual(): void {
   assert(result instanceof Child);
   let cast = <Child>result;
   assert(cast.a == 42);
+}
+
+class NullableCustom {
+  b: CustomSerialize | null = new CustomSerialize();
+}
+
+function testNullableCustom(): void {
+  let actual = new NullableCustom();
+  let expected = ASON.deserialize<NullableCustom>(ASON.serialize(actual));
+  expect(actual).toStrictEqual(expected);
+  expect(actual).not.toBe(expected);
+  assert(expected instanceof NullableCustom);
 }


### PR DESCRIPTION
```
ERROR TS2322: Type '~lib/as-lunatic/process/index/Process<i32> | null' is not assignable to type '~lib/as-lunatic/process/index/Process<i32>'.

       let buffer: StaticArray<u8> = value.__asonSerialize();
                                     ~~~~~
 in ~lib/@ason/assembly/index.ts(225,37)
 ```
 
Looks like `value` can be nullable. So we do a runtime assertion that the value cannot be null before `putCustom<U>(value)` is even called.

There is a test case for this now to validate that it compiles.