### PR TITLE
Implement Instanceof

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
     "": {
       "name": "ason",
       "version": "0.0.4",
-      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "assembly",
         "transform"
       ],
       "dependencies": {
+        "@assemblyscript/loader": "^0.24.0",
         "visitor-as": "^0.11.3"
       },
       "devDependencies": {
@@ -149,6 +149,11 @@
       "dependencies": {
         "assemblyscript": "^0.24.0"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.24.1.tgz",
+      "integrity": "sha512-22ZeD6aX8J/Yy02ABQgV09aJnpA6NdRFQTaH58POnhZ3GazMT00rlsxkWrIw3RrNY2ILiGVsyCWg5HwYOTL9xw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -9494,6 +9499,11 @@
       "requires": {
         "assemblyscript": "^0.24.0"
       }
+    },
+    "@assemblyscript/loader": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.24.1.tgz",
+      "integrity": "sha512-22ZeD6aX8J/Yy02ABQgV09aJnpA6NdRFQTaH58POnhZ3GazMT00rlsxkWrIw3RrNY2ILiGVsyCWg5HwYOTL9xw=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",

--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -858,12 +858,11 @@ export namespace ASON {
       if (isReference<T>()) {
         // in the case of functions, idof<T>() returns 0, and breaks everything
         if (!isFunction<T>()) {
-          
-          if (isDefined(__instanceof)) {
-            assert(getObjectType(entry0) == idof<T>() || __instanceof(entry0, idof<T>()));
+          let dummy = changetype<T>(__new(offsetof<T>(), idof<T>()));
+          if (isNullable<T>()) {
+            dummy!.__asonInstanceOf(getObjectType(entry0));
           } else {
-            // @ts-ignore
-            assert(changetype<Object>(entry0) instanceof T)
+            dummy.__asonInstanceOf(getObjectType(entry0));
           }
         }
       } else {

--- a/packages/transform/src/createAsonInstanceOfMethod.ts
+++ b/packages/transform/src/createAsonInstanceOfMethod.ts
@@ -1,0 +1,122 @@
+import {
+    ClassDeclaration,
+    CommonFlags,
+    Statement,
+    TypeNode,
+    ParameterKind,
+    InterfaceDeclaration,
+    FunctionDeclaration,
+    Token,
+  } from "assemblyscript/dist/assemblyscript.js";
+
+
+export function createAsonInstanceOfMethod(classDeclaration: ClassDeclaration): void {
+    let statements = <Statement[]>[
+        // if (id == idof<this>()) return true;
+        TypeNode.createIfStatement(
+            TypeNode.createBinaryExpression(
+                Token.Equals_Equals,
+                TypeNode.createIdentifierExpression("id", classDeclaration.range),
+                TypeNode.createCallExpression(
+                    TypeNode.createIdentifierExpression("idof", classDeclaration.range),
+                    [
+                        TypeNode.createNamedType(
+                            TypeNode.createSimpleTypeName("this", classDeclaration.range),
+                            null,
+                            false,
+                            classDeclaration.range,
+                        ),
+                    ],
+                    [],
+                    classDeclaration.range
+                ),
+                classDeclaration.range,
+            ),
+            TypeNode.createReturnStatement(TypeNode.createTrueExpression(classDeclaration.range), classDeclaration.range),
+            null,
+            classDeclaration.range,
+        ),
+    ];
+
+    // if (isDefined(super.__asonInstanceOf)) return super.__asonInstanceOf(id);
+    statements.push(
+        TypeNode.createIfStatement(
+            TypeNode.createCallExpression(
+                TypeNode.createIdentifierExpression("isDefined", classDeclaration.range),
+                null,
+                [
+                    TypeNode.createPropertyAccessExpression(
+                        TypeNode.createSuperExpression(classDeclaration.range),
+                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
+                        classDeclaration.range,
+                    )
+                ],
+                classDeclaration.range,
+            ),
+            TypeNode.createReturnStatement(
+                TypeNode.createCallExpression(
+                    TypeNode.createPropertyAccessExpression(
+                        TypeNode.createSuperExpression(classDeclaration.range),
+                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
+                        classDeclaration.range,
+                    ),
+                    null,
+                    [
+                        TypeNode.createIdentifierExpression("id", classDeclaration.range),
+                    ],
+                    classDeclaration.range,
+                ),
+                classDeclaration.range,
+            ),
+            null,
+            classDeclaration.range,
+        ),
+    );
+
+    // return false;
+    statements.push(
+        TypeNode.createReturnStatement(
+            TypeNode.createFalseExpression(classDeclaration.range),
+            classDeclaration.range,
+        ),
+    );
+
+    let method = TypeNode.createMethodDeclaration(
+        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
+        null,
+        CommonFlags.Public |
+            CommonFlags.Instance |
+            (classDeclaration.isGeneric ? CommonFlags.GenericContext : 0),
+        null,
+        TypeNode.createFunctionType(
+        [
+            // ser: Serializer<U>,
+            TypeNode.createParameter(
+            ParameterKind.Default,
+            TypeNode.createIdentifierExpression("id", classDeclaration.range),
+            TypeNode.createNamedType(
+                TypeNode.createSimpleTypeName("usize", classDeclaration.range),
+                null,
+                false,
+                classDeclaration.range
+            ),
+            null,
+            classDeclaration.range
+            ),
+        ],
+        TypeNode.createNamedType(
+            TypeNode.createSimpleTypeName("bool", classDeclaration.range),
+            null,
+            false,
+            classDeclaration.range
+        ),
+        null,
+        false,
+        classDeclaration.range
+        ),
+        TypeNode.createBlockStatement(statements, classDeclaration.range),
+        classDeclaration.range
+    );
+
+    classDeclaration.members.push(method);
+}

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   Transform,
 } from "assemblyscript/dist/transform.js";
+import { createAsonInstanceOfMethod } from "./createAsonInstanceOfMethod.js";
 
 
 import { createAsonPutMethod } from "./createAsonPutMethod.js";
@@ -40,6 +41,7 @@ function traverseStatements(statements: Statement[]): void {
       // cast and create a strictEquals function
       const classDeclaration = <ClassDeclaration>statement;
       createAsonPutMethod(classDeclaration);
+      createAsonInstanceOfMethod(classDeclaration);
     } else if (statement.kind === NodeKind.NamespaceDeclaration) {
       const namespaceDeclaration = <NamespaceDeclaration>statement;
       traverseStatements(namespaceDeclaration.members);


### PR DESCRIPTION
This is a replacement for type checking involving using the `instanceof` operator which for some reason is broken when it feels like it.

All class instances now have a __asonInstanceOf(id) method which requires an additional heap allocation just to validate the type of the object that is being assembled as deserialization time.

```ts
    if (isReference<T>()) {
        // in the case of functions, idof<T>() returns 0, and breaks everything
        if (!isFunction<T>()) {
          let dummy = changetype<T>(__new(offsetof<T>(), idof<T>()));
          if (isNullable<T>()) {
            dummy!.__asonInstanceOf(getObjectType(entry0));
          } else {
            dummy.__asonInstanceOf(getObjectType(entry0));
          }
        }
      } else {
        // the type is a number, and we can validate the rtid of a Box<T>
        assert(getObjectType(entry0) == idof<Box<T>>());
      }
 ```

In the case where we must actually validate instanceof, we allocate a dummy reference, and call `__asonInstanceOf(id)` where id it the actual output id of the deserialized reference. Internally we simply check to see if the value exists in class id.