### PR TITLE
Add a __asonNameof method to every class

### DIFF
--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -102,7 +102,7 @@ export namespace ASON {
           // @ts-ignore inside isDefined()
           if (isDefined(ASON_TRACE)) {
             // @ts-ignore interface added at runtime
-            trace(`serializing ${(value as InternalNameofInterface).__asonNameof()}`);
+            trace(`serializing ${(value as InternalTransformInterface).__asonNameof()}`);
           }
         }
       }
@@ -148,7 +148,7 @@ export namespace ASON {
         if (isManaged(value) && !isFunction(value)) {
           if (isDefined(ASON_TRACE)) {
             // @ts-ignore interface added at runtime
-            trace(`putting ${(value as InternalNameofInterface).__asonNameof()}`);
+            trace(`putting ${(value as InternalTransformInterface).__asonNameof()}`);
           }
         }
       }
@@ -887,7 +887,7 @@ export namespace ASON {
           if (!success) {
             // @ts-ignore inside isDefined()
             if (isDefined(ASON_TRACE)) {
-              assert(false, `Deserialize: expected ${nameof<T>()}, received ${changetype<InternalNameofInterface>(entry0).__asonNameof()}`);
+              assert(false, `Deserialize: expected ${nameof<T>()}, received ${changetype<InternalTransformInterface>(entry0).__asonNameof()}`);
             } else {
               assert(false, `Deserialize: received invalid type`);
             }
@@ -1183,7 +1183,7 @@ export namespace ASON {
     return a.deserialize(buffer);
   }
 
-  interface InternalNameofInterface {
+  interface InternalTransformInterface {
     __asonNameof(): string
   }
 }

--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -1185,5 +1185,8 @@ export namespace ASON {
 
   interface InternalTransformInterface {
     __asonNameof(): string
+    __asonPut<U>(ser: U, entryId: u32): void
+    __asonAlignofValueofParameter(): usize
+    __asonLength(): i32
   }
 }

--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -393,10 +393,10 @@ export namespace ASON {
       let entryId = this.putReference(value);
       if (isNullable(value)) {
         // @ts-ignore: defined in each class
-        value!.__asonPut(this, entryId);
+        (value! as InternalTransformInterface).__asonPut(this, entryId);
       } else {
         // @ts-ignore: defined in each class
-        value.__asonPut(this, entryId);
+        (value as InternalTransformInterface).__asonPut(this, entryId);
       }
       return entryId;
     }
@@ -424,28 +424,19 @@ export namespace ASON {
       let entryId = this.entryId++;
       this.entries.set(changetype<usize>(value), entryId);
 
-      let arrayLength: i32;
-
-      if (isNullable<U>()) {
-        // @ts-ignore: array / typedarray length is defined
-        arrayLength = value!.length;
-      } else {
-        // @ts-ignore: array / typedarray length is defined
-        arrayLength = value.length;
-      }
+      let arrayLength = (value as InternalTransformInterface).__asonLength();
 
       let entry = this.arrayDataSegmentTable.allocate();
+      const align = (value as InternalTransformInterface).__asonAlignofValueofParameter();
       entry.length = arrayLength;
-      // @ts-ignore: valueof<U> is defined
-      entry.align = alignof<valueof<U>>();
+      entry.align = align;
       entry.entryId = entryId;
       entry.rtId = getObjectType(changetype<usize>(value));
 
-      // @ts-ignore: valueof<U> is defined
-      let size = <usize>arrayLength << (alignof<valueof<U>>());
+      let size = <usize>arrayLength << align;
 
       // copy the data
-      let dataStart = load<usize>(changetype<usize>(value), offsetof<U>("dataStart"));
+      let dataStart = load<usize>(changetype<usize>(value), offsetof<ArrayBufferView>("dataStart"));
 
       let segment = this.arrayDataSegmentTable.allocateSegment(<i32>size);
       memory.copy(segment, dataStart, size);

--- a/packages/assembly/index.ts
+++ b/packages/assembly/index.ts
@@ -1159,4 +1159,8 @@ export namespace ASON {
     let a = new Deserializer<T>();
     return a.deserialize(buffer);
   }
+
+  interface InternalNameofInterface {
+    __asonNameof(): string
+  }
 }

--- a/packages/test/as-pect.asconfig.json
+++ b/packages/test/as-pect.asconfig.json
@@ -15,7 +15,7 @@
     "bindings": "raw",
     "exportStart": "_start",
     "exportRuntime": true,
-    "use": ["RTRACE=1"],
+    "use": ["RTRACE=1", "ASON_TRACE=1"],
     "debug": true,
     "exportTable": true
   },

--- a/packages/test/assembly/__tests__/index.spec.ts
+++ b/packages/test/assembly/__tests__/index.spec.ts
@@ -79,6 +79,7 @@ describe("ASON test suite", () => {
   test("Major objects that should engage all parts of ASON", testHugeObject);
 
   test("nullable custom", testNullableCustom);
+  test("object deserialization", testPlainObjectDeserialization);
 });
 
 function testBasicVectors(): void {
@@ -440,4 +441,14 @@ function testNullableCustom(): void {
   expect(actual).toStrictEqual(expected);
   expect(actual).not.toBe(expected);
   assert(expected instanceof NullableCustom);
+}
+
+function testPlainObjectDeserialization(): void {
+  const actual = new Vec3(12, 34, 56);
+  const processed = ASON.deserialize<Object>(ASON.serialize(actual));
+  assert(processed instanceof Vec3);
+
+  const casted = processed as Vec3;
+  expect(actual).toStrictEqual(casted);
+  expect(actual).not.toBe(casted);
 }

--- a/packages/test/assembly/__tests__/index.spec.ts
+++ b/packages/test/assembly/__tests__/index.spec.ts
@@ -79,7 +79,7 @@ describe("ASON test suite", () => {
   test("Major objects that should engage all parts of ASON", testHugeObject);
 
   test("nullable custom", testNullableCustom);
-  test("object deserialization", testPlainObjectDeserialization);
+  test("object (de)serialization", testPlainObject);
 });
 
 function testBasicVectors(): void {
@@ -443,9 +443,9 @@ function testNullableCustom(): void {
   assert(expected instanceof NullableCustom);
 }
 
-function testPlainObjectDeserialization(): void {
+function testPlainObject(): void {
   const actual = new Vec3(12, 34, 56);
-  const processed = ASON.deserialize<Object>(ASON.serialize(actual));
+  const processed = ASON.deserialize<Object>(ASON.serialize<Object>(actual));
   assert(processed instanceof Vec3);
 
   const casted = processed as Vec3;

--- a/packages/test/assembly/__tests__/index.spec.ts
+++ b/packages/test/assembly/__tests__/index.spec.ts
@@ -44,7 +44,7 @@ describe("ASON test suite", () => {
   test("really long static strings", testStaticStrings);
   test("typed array", testTypedArray);
   test("extension", objectExtension);
-  test("funtions", testCallbacks);
+  test("functions", testCallbacks);
 
   describe("map", () => {
     test("int to int maps", () => { testMap<u8, u8>([1, 2, 3], [3, 6, 9]); });

--- a/packages/transform/src/createAsonAlignofValueofMethod.ts
+++ b/packages/transform/src/createAsonAlignofValueofMethod.ts
@@ -1,0 +1,62 @@
+import {CommonFlags, ClassDeclaration, Node} from "assemblyscript/dist/assemblyscript.js";
+
+export function createAsonAlignofValueofMethod({range, isGeneric, members, indexSignature}: ClassDeclaration): void {
+    members.push(
+        Node.createMethodDeclaration(
+            Node.createIdentifierExpression("__asonAlignofValueofParameter", range),
+            null,
+            (
+                CommonFlags.Public |
+                CommonFlags.Instance |
+                (isGeneric ? CommonFlags.GenericContext : 0)
+            ),
+            null,
+            Node.createFunctionType(
+                [],
+                Node.createNamedType(
+                    Node.createSimpleTypeName("usize", range),
+                    null,
+                    false,
+                    range
+                ),
+                null,
+                false,
+                range
+            ),
+            Node.createBlockStatement(
+                [
+                    Node.createReturnStatement(
+                        indexSignature
+                            ? Node.createCallExpression(
+                                Node.createIdentifierExpression("alignof", range),
+                                [
+                                    Node.createNamedType(
+                                        Node.createSimpleTypeName("valueof", range),
+                                        [
+                                            Node.createNamedType(
+                                                Node.createSimpleTypeName("this", range),
+                                                null,
+                                                false,
+                                                range
+                                            )
+                                        ],
+                                        false,
+                                        range
+                                    )
+                                ],
+                                [],
+                                range
+                            )
+                            : Node.createIntegerLiteralExpression(
+                                {low: 0, high: 0} as unknown as i64,
+                                range
+                            ),
+                        range
+                    )
+                ],
+                range
+            ),
+            range
+        )
+    );
+}

--- a/packages/transform/src/createAsonInstanceOfMethod.ts
+++ b/packages/transform/src/createAsonInstanceOfMethod.ts
@@ -4,8 +4,6 @@ import {
     Statement,
     TypeNode,
     ParameterKind,
-    InterfaceDeclaration,
-    FunctionDeclaration,
     Token,
   } from "assemblyscript/dist/assemblyscript.js";
 
@@ -16,25 +14,25 @@ export function createAsonInstanceOfMethod(classDeclaration: ClassDeclaration): 
         TypeNode.createIfStatement(
             TypeNode.createBinaryExpression(
                 Token.Equals_Equals,
-                TypeNode.createIdentifierExpression("id", classDeclaration.range),
+                TypeNode.createIdentifierExpression("id", classDeclaration.name.range),
                 TypeNode.createCallExpression(
-                    TypeNode.createIdentifierExpression("idof", classDeclaration.range),
+                    TypeNode.createIdentifierExpression("idof", classDeclaration.name.range),
                     [
                         TypeNode.createNamedType(
-                            TypeNode.createSimpleTypeName("this", classDeclaration.range),
+                            TypeNode.createSimpleTypeName("this", classDeclaration.name.range),
                             null,
                             false,
-                            classDeclaration.range,
+                            classDeclaration.name.range,
                         ),
                     ],
                     [],
-                    classDeclaration.range
+                    classDeclaration.name.range
                 ),
-                classDeclaration.range,
+                classDeclaration.name.range,
             ),
-            TypeNode.createReturnStatement(TypeNode.createTrueExpression(classDeclaration.range), classDeclaration.range),
+            TypeNode.createReturnStatement(TypeNode.createTrueExpression(classDeclaration.name.range), classDeclaration.name.range),
             null,
-            classDeclaration.range,
+            classDeclaration.name.range,
         ),
     ];
 
@@ -42,47 +40,47 @@ export function createAsonInstanceOfMethod(classDeclaration: ClassDeclaration): 
     statements.push(
         TypeNode.createIfStatement(
             TypeNode.createCallExpression(
-                TypeNode.createIdentifierExpression("isDefined", classDeclaration.range),
+                TypeNode.createIdentifierExpression("isDefined", classDeclaration.name.range),
                 null,
                 [
                     TypeNode.createPropertyAccessExpression(
-                        TypeNode.createSuperExpression(classDeclaration.range),
-                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
-                        classDeclaration.range,
+                        TypeNode.createSuperExpression(classDeclaration.name.range),
+                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.name.range),
+                        classDeclaration.name.range,
                     )
                 ],
-                classDeclaration.range,
+                classDeclaration.name.range,
             ),
             TypeNode.createReturnStatement(
                 TypeNode.createCallExpression(
                     TypeNode.createPropertyAccessExpression(
-                        TypeNode.createSuperExpression(classDeclaration.range),
-                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
-                        classDeclaration.range,
+                        TypeNode.createSuperExpression(classDeclaration.name.range),
+                        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.name.range),
+                        classDeclaration.name.range,
                     ),
                     null,
                     [
-                        TypeNode.createIdentifierExpression("id", classDeclaration.range),
+                        TypeNode.createIdentifierExpression("id", classDeclaration.name.range),
                     ],
-                    classDeclaration.range,
+                    classDeclaration.name.range,
                 ),
-                classDeclaration.range,
+                classDeclaration.name.range,
             ),
             null,
-            classDeclaration.range,
+            classDeclaration.name.range,
         ),
     );
 
     // return false;
     statements.push(
         TypeNode.createReturnStatement(
-            TypeNode.createFalseExpression(classDeclaration.range),
-            classDeclaration.range,
+            TypeNode.createFalseExpression(classDeclaration.name.range),
+            classDeclaration.name.range,
         ),
     );
 
     let method = TypeNode.createMethodDeclaration(
-        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.range),
+        TypeNode.createIdentifierExpression("__asonInstanceOf", classDeclaration.name.range),
         null,
         CommonFlags.Public |
             CommonFlags.Instance |
@@ -93,29 +91,29 @@ export function createAsonInstanceOfMethod(classDeclaration: ClassDeclaration): 
             // ser: Serializer<U>,
             TypeNode.createParameter(
             ParameterKind.Default,
-            TypeNode.createIdentifierExpression("id", classDeclaration.range),
+            TypeNode.createIdentifierExpression("id", classDeclaration.name.range),
             TypeNode.createNamedType(
-                TypeNode.createSimpleTypeName("usize", classDeclaration.range),
+                TypeNode.createSimpleTypeName("usize", classDeclaration.name.range),
                 null,
                 false,
-                classDeclaration.range
+                classDeclaration.name.range
             ),
             null,
-            classDeclaration.range
+            classDeclaration.name.range
             ),
         ],
         TypeNode.createNamedType(
-            TypeNode.createSimpleTypeName("bool", classDeclaration.range),
+            TypeNode.createSimpleTypeName("bool", classDeclaration.name.range),
             null,
             false,
-            classDeclaration.range
+            classDeclaration.name.range
         ),
         null,
         false,
-        classDeclaration.range
+        classDeclaration.name.range
         ),
-        TypeNode.createBlockStatement(statements, classDeclaration.range),
-        classDeclaration.range
+        TypeNode.createBlockStatement(statements, classDeclaration.name.range),
+        classDeclaration.name.range
     );
 
     classDeclaration.members.push(method);

--- a/packages/transform/src/createAsonLengthMethod.ts
+++ b/packages/transform/src/createAsonLengthMethod.ts
@@ -1,0 +1,69 @@
+import {CommonFlags, ClassDeclaration, Statement, Node} from "assemblyscript/dist/assemblyscript.js";
+
+export function createAsonLengthMethod({name, range, isGeneric, members}: ClassDeclaration): void {
+    const statements: Statement[] = [
+        Node.createReturnStatement(
+            Node.createIntegerLiteralExpression(
+                {low: 0, high: 0} as unknown as i64,
+                range
+            ),
+            range
+        )
+    ];
+
+    if (name.text !== "Function") {
+        statements.unshift(
+            Node.createIfStatement(
+                Node.createCallExpression(
+                    Node.createIdentifierExpression("isDefined", range),
+                    null,
+                    [
+                        Node.createPropertyAccessExpression(
+                            Node.createThisExpression(range),
+                            Node.createIdentifierExpression("length", range),
+                            range
+                        )
+                    ],
+                    range
+                ),
+                Node.createReturnStatement(
+                    Node.createPropertyAccessExpression(
+                        Node.createThisExpression(range),
+                        Node.createIdentifierExpression("length", range),
+                        range
+                    ),
+                    range
+                ),
+                null,
+                range
+            )
+        );
+    }
+
+    members.push(
+        Node.createMethodDeclaration(
+            Node.createIdentifierExpression("__asonLength", range),
+            null,
+            (
+                CommonFlags.Public |
+                CommonFlags.Instance |
+                (isGeneric ? CommonFlags.GenericContext : 0)
+            ),
+            null,
+            Node.createFunctionType(
+                [],
+                Node.createNamedType(
+                    Node.createSimpleTypeName("i32", range),
+                    null,
+                    false,
+                    range
+                ),
+                null,
+                false,
+                range
+            ),
+            Node.createBlockStatement(statements, range),
+            range
+        )
+    );
+}

--- a/packages/transform/src/createAsonNameofMethod.ts
+++ b/packages/transform/src/createAsonNameofMethod.ts
@@ -1,0 +1,51 @@
+import {CommonFlags, ClassDeclaration, Node} from "assemblyscript/dist/assemblyscript.js";
+
+export function createAsonNameofMethod({name, range, isGeneric, members}: ClassDeclaration): void {
+    if (name.text === "InternalNameofInterface") return;
+    members.push(
+        Node.createMethodDeclaration(
+            Node.createIdentifierExpression("__asonNameof", range),
+            null,
+            (
+                CommonFlags.Public |
+                CommonFlags.Instance |
+                (isGeneric ? CommonFlags.GenericContext : 0)
+            ),
+            null,
+            Node.createFunctionType(
+                [],
+                Node.createNamedType(
+                    Node.createSimpleTypeName("string", range),
+                    null,
+                    false,
+                    range
+                ),
+                null,
+                false,
+                range
+            ),
+            Node.createBlockStatement(
+                [
+                    Node.createReturnStatement(
+                        Node.createCallExpression(
+                            Node.createIdentifierExpression("nameof", range),
+                            [
+                                Node.createNamedType(
+                                    Node.createSimpleTypeName("this", range),
+                                    null,
+                                    false,
+                                    range
+                                )
+                            ],
+                            [],
+                            range
+                        ),
+                        range
+                    )
+                ],
+                range
+            ),
+            range
+        )
+    );
+}

--- a/packages/transform/src/createAsonNameofMethod.ts
+++ b/packages/transform/src/createAsonNameofMethod.ts
@@ -1,7 +1,6 @@
 import {CommonFlags, ClassDeclaration, Node} from "assemblyscript/dist/assemblyscript.js";
 
-export function createAsonNameofMethod({name, range, isGeneric, members}: ClassDeclaration): void {
-    if (name.text === "InternalTransformInterface") return;
+export function createAsonNameofMethod({range, isGeneric, members}: ClassDeclaration): void {
     members.push(
         Node.createMethodDeclaration(
             Node.createIdentifierExpression("__asonNameof", range),

--- a/packages/transform/src/createAsonNameofMethod.ts
+++ b/packages/transform/src/createAsonNameofMethod.ts
@@ -1,7 +1,7 @@
 import {CommonFlags, ClassDeclaration, Node} from "assemblyscript/dist/assemblyscript.js";
 
 export function createAsonNameofMethod({name, range, isGeneric, members}: ClassDeclaration): void {
-    if (name.text === "InternalNameofInterface") return;
+    if (name.text === "InternalTransformInterface") return;
     members.push(
         Node.createMethodDeclaration(
             Node.createIdentifierExpression("__asonNameof", range),

--- a/packages/transform/src/createAsonPutMethod.ts
+++ b/packages/transform/src/createAsonPutMethod.ts
@@ -26,7 +26,7 @@ export function createAsonPutMethod(classDeclaration: ClassDeclaration): void {
   statements.push(createSuperAsonPutCall(classDeclaration));
 
   let method = TypeNode.createMethodDeclaration(
-    TypeNode.createIdentifierExpression("__asonPut", classDeclaration.range),
+    TypeNode.createIdentifierExpression("__asonPut", classDeclaration.name.range),
     null,
     CommonFlags.Public |
       CommonFlags.Instance |
@@ -34,10 +34,10 @@ export function createAsonPutMethod(classDeclaration: ClassDeclaration): void {
       (classDeclaration.isGeneric ? CommonFlags.GenericContext : 0),
     [
       TypeNode.createTypeParameter(
-        TypeNode.createIdentifierExpression("U", classDeclaration.range),
+        TypeNode.createIdentifierExpression("U", classDeclaration.name.range),
         null,
         null,
-        classDeclaration.range
+        classDeclaration.name.range
       ),
     ],
     TypeNode.createFunctionType(
@@ -45,45 +45,45 @@ export function createAsonPutMethod(classDeclaration: ClassDeclaration): void {
         // ser: Serializer<U>,
         TypeNode.createParameter(
           ParameterKind.Default,
-          TypeNode.createIdentifierExpression("ser", classDeclaration.range),
+          TypeNode.createIdentifierExpression("ser", classDeclaration.name.range),
           TypeNode.createNamedType(
-            TypeNode.createSimpleTypeName("U", classDeclaration.range),
+            TypeNode.createSimpleTypeName("U", classDeclaration.name.range),
             null,
             false,
-            classDeclaration.range
+            classDeclaration.name.range
           ),
           null,
-          classDeclaration.range
+          classDeclaration.name.range
         ),
         // entryId: u32,
         TypeNode.createParameter(
           ParameterKind.Default,
           TypeNode.createIdentifierExpression(
             "entryId",
-            classDeclaration.range
+            classDeclaration.name.range
           ),
           TypeNode.createNamedType(
-            TypeNode.createSimpleTypeName("u32", classDeclaration.range),
+            TypeNode.createSimpleTypeName("u32", classDeclaration.name.range),
             null,
             false,
-            classDeclaration.range
+            classDeclaration.name.range
           ),
           null,
-          classDeclaration.range
+          classDeclaration.name.range
         ),
       ],
       TypeNode.createNamedType(
-        TypeNode.createSimpleTypeName("void", classDeclaration.range),
+        TypeNode.createSimpleTypeName("void", classDeclaration.name.range),
         null,
         false,
-        classDeclaration.range
+        classDeclaration.name.range
       ),
       null,
       false,
-      classDeclaration.range
+      classDeclaration.name.range
     ),
-    TypeNode.createBlockStatement(statements, classDeclaration.range),
-    classDeclaration.range
+    TypeNode.createBlockStatement(statements, classDeclaration.name.range),
+    classDeclaration.name.range
   );
   classDeclaration.members.push(method);
 }
@@ -166,39 +166,39 @@ function createSuperAsonPutCall(
   // if (isDefined(super.__asonPut))
   return TypeNode.createIfStatement(
     TypeNode.createCallExpression(
-      TypeNode.createIdentifierExpression("isDefined", classDeclaration.range),
+      TypeNode.createIdentifierExpression("isDefined", classDeclaration.name.range),
       null,
       [
         TypeNode.createPropertyAccessExpression(
-          TypeNode.createSuperExpression(classDeclaration.range),
+          TypeNode.createSuperExpression(classDeclaration.name.range),
           TypeNode.createIdentifierExpression(
             "__asonPut",
-            classDeclaration.range
+            classDeclaration.name.range
           ),
-          classDeclaration.range
+          classDeclaration.name.range
         ),
       ],
-      classDeclaration.range
+      classDeclaration.name.range
     ),
     TypeNode.createExpressionStatement(
       TypeNode.createCallExpression(
         TypeNode.createPropertyAccessExpression(
-          TypeNode.createSuperExpression(classDeclaration.range),
+          TypeNode.createSuperExpression(classDeclaration.name.range),
           TypeNode.createIdentifierExpression(
             "__asonPut",
-            classDeclaration.range
+            classDeclaration.name.range
           ),
-          classDeclaration.range
+          classDeclaration.name.range
         ),
         null,
         [
-          TypeNode.createIdentifierExpression("ser", classDeclaration.range),
-          TypeNode.createIdentifierExpression("entryId", classDeclaration.range),
+          TypeNode.createIdentifierExpression("ser", classDeclaration.name.range),
+          TypeNode.createIdentifierExpression("entryId", classDeclaration.name.range),
         ],
-        classDeclaration.range
+        classDeclaration.name.range
       )
     ),
     null,
-    classDeclaration.range
+    classDeclaration.name.range
   );
 }

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -21,6 +21,8 @@ import { createAsonInstanceOfMethod } from "./createAsonInstanceOfMethod.js";
 import { createAsonPutMethod } from "./createAsonPutMethod.js";
 import { createAsonNameofMethod } from "./createAsonNameofMethod.js";
 
+const INTERNAL_TRANSFORM_NAME = "InternalTransformInterface"
+
 export default class ASONTransform extends Transform {
   /**
    * This method results in a pure AST transform that inserts a strictEquals member
@@ -46,7 +48,7 @@ export default class ASONTransform extends Transform {
       }) as ClassPrototype[];
 
     const [internalInterface] = classes.splice(
-      classes.findIndex(clazz => clazz.internalName.endsWith("ASON.InternalTransformInterface")),
+      classes.findIndex(clazz => clazz.internalName.endsWith("ASON." + INTERNAL_TRANSFORM_NAME)),
       1
     );
     const baseMethod = internalInterface.instanceMembers!.get("__asonNameof")! as FunctionPrototype;
@@ -60,7 +62,7 @@ export default class ASONTransform extends Transform {
       declaration.implementsTypes ??= [];
       declaration.implementsTypes.push(
         Node.createNamedType(
-          Node.createSimpleTypeName("InternalTransformInterface", range),
+          Node.createSimpleTypeName(INTERNAL_TRANSFORM_NAME, range),
           null,
           false,
           range
@@ -96,6 +98,10 @@ function traverseStatements(statements: Statement[]): void {
       createAsonNameofMethod(classDeclaration);
     } else if (statement.kind === NodeKind.InterfaceDeclaration) {
       const interfaceDeclaration = <InterfaceDeclaration>statement;
+
+      // Don't declare methods on the internal interface
+      if (interfaceDeclaration.name.text === INTERNAL_TRANSFORM_NAME) continue;
+
       createAsonNameofMethod(interfaceDeclaration);
     } else if (statement.kind === NodeKind.NamespaceDeclaration) {
       const namespaceDeclaration = <NamespaceDeclaration>statement;

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -72,6 +72,10 @@ export default class ASONTransform extends Transform {
         clazz.instanceMembers!.get("__asonNameof")! as FunctionPrototype
       );
     });
+
+    const resolvedInternalInterface = program.resolver.resolveClass(internalInterface, null)!;
+    const resolvedClasses = [program.stringInstance, program.arrayBufferInstance, program.arrayBufferViewInstance];
+    resolvedClasses.forEach(clazz => clazz.addInterface(resolvedInternalInterface));
   }
 };
 

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -46,7 +46,7 @@ export default class ASONTransform extends Transform {
       }) as ClassPrototype[];
 
     const [internalInterface] = classes.splice(
-      classes.findIndex(clazz => clazz.internalName.endsWith("ASON.InternalNameofInterface")),
+      classes.findIndex(clazz => clazz.internalName.endsWith("ASON.InternalTransformInterface")),
       1
     );
     const baseMethod = internalInterface.instanceMembers!.get("__asonNameof")! as FunctionPrototype;
@@ -60,7 +60,7 @@ export default class ASONTransform extends Transform {
       declaration.implementsTypes ??= [];
       declaration.implementsTypes.push(
         Node.createNamedType(
-          Node.createSimpleTypeName("InternalNameofInterface", range),
+          Node.createSimpleTypeName("InternalTransformInterface", range),
           null,
           false,
           range

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -74,7 +74,12 @@ export default class ASONTransform extends Transform {
     });
 
     const resolvedInternalInterface = program.resolver.resolveClass(internalInterface, null)!;
-    const resolvedClasses = [program.stringInstance, program.arrayBufferInstance, program.arrayBufferViewInstance];
+    const resolvedClasses = [
+      program.objectInstance,
+      program.stringInstance,
+      program.arrayBufferInstance,
+      program.arrayBufferViewInstance
+    ];
     resolvedClasses.forEach(clazz => clazz.addInterface(resolvedInternalInterface));
   }
 };


### PR DESCRIPTION
__asonNameof() is a virtual method that simply returns nameof<this>(). This is useful for debugging objects whose types are only known at runtime, i.e. objects in ASON deserialization.