### PR TITLE
Only add class methods to unboundOverrides

### DIFF
--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -76,6 +76,8 @@ export default class ASONTransform extends Transform {
         )
       );
 
+      if (clazz.kind === ElementKind.InterfacePrototype) return;
+
       for (const [name, method] of baseMethods) {
         method.unboundOverrides ??= new Set();
         method.unboundOverrides.add(


### PR DESCRIPTION
If an element in unboundOverrides is an interface method, the compiler hits an assertion in src/resolver.ts, line 3008:
```ts
  resolveOverrides(instance: Function): Function[] | null {
    let overridePrototypes = instance.prototype.unboundOverrides;
    // ...
    for (let _values = Set_values(overridePrototypes) /* ... */ ) {
      let unboundOverridePrototype = _values[i];
      // ...
      let unboundOverrideParent = unboundOverridePrototype.parent;
      // ...
      // The assertion below fails:
      assert(unboundOverrideParent.kind == ElementKind.ClassPrototype);
      // ...
    }
    // ...
  }
```
This commit fixes that issue.